### PR TITLE
added docstring for add_views

### DIFF
--- a/restless/pyr.py
+++ b/restless/pyr.py
@@ -31,29 +31,47 @@ class PyramidResource(Resource):
         return resp
 
     @classmethod
-    def add_views(cls, config, rule_prefix, endpoint_prefix=None):
+    def add_views(cls, config, rule_prefix, routename_prefix=None):
+        """
+        A convenience method for registering the routes and views in pyramid.
+
+        This automatically adds a list and detail endpoint to your routes.
+
+        :param config: The pyramid ``Configurator`` object for your app.
+        :type config: ``pyramid.config.Configurator``
+
+        :param rule_prefix: The start of the URL to handle.
+        :type rule_prefix: string
+
+        :param routename_prefix: (Optional) A prefix for the route's name.
+            The default is ``None``, which will autocreate a prefix based on the
+            class name. Ex: ``PostResource`` -> ``api_post_list``
+        :type routename_prefix: string
+
+        :returns: ``pyramid.config.Configurator``
+        """
         methods = ('GET', 'POST', 'PUT', 'DELETE')
-        if endpoint_prefix is None:
-            endpoint_prefix = 'api_{0}'.format(
+        if routename_prefix is None:
+            routename_prefix = 'api_{0}'.format(
                 cls.__name__.replace('Resource', '').lower()
             )
         config.add_route(
-            endpoint_prefix + '_list',
+            routename_prefix + '_list',
             rule_prefix
         )
         config.add_view(
             cls.as_list(),
-            route_name=endpoint_prefix + '_list',
+            route_name=routename_prefix + '_list',
             request_method=methods
         )
 
         config.add_route(
-            endpoint_prefix + '_detail',
+            routename_prefix + '_detail',
             rule_prefix + '{name}/'
         )
         config.add_view(
             cls.as_detail(),
-            route_name=endpoint_prefix + '_detail',
+            route_name=routename_prefix + '_detail',
             request_method=methods
         )
         return config


### PR DESCRIPTION
I forgot to add this to the pr last night. It adds a docstring and cleans up the method signature to be more in line with pyramid naming
