### PR TITLE
Add forgotten import in the Manifesto example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,14 +74,14 @@ Example code:
     from django.contrib.auth.models import User
 
     from restless.dj import DjangoResource
-    from restless.preparers import Preparer
+    from restless.preparers import FieldsPreparer
 
     from posts.models import Post
 
 
     class PostResource(DjangoResource):
         # Controls what data is included in the serialized output.
-        preparer = Preparer(fields={
+        preparer = FieldsPreparer(fields={
             'id': 'id',
             'title': 'title',
             'author': 'user.username',


### PR DESCRIPTION
The example in the Manifesto section in README.rst used the `Preparer` class without having imported it.  

Signed-off-by: Balthazar Rouberol balthazar.rouberol@mapado.com
