### PR TITLE
Call csrf_exempt on DjangoResource.as_view.

### DIFF
--- a/restless/dj.py
+++ b/restless/dj.py
@@ -26,6 +26,10 @@ class DjangoResource(Resource):
     def as_detail(self, *args, **kwargs):
         return csrf_exempt(super(DjangoResource, self).as_detail(*args, **kwargs))
 
+    @classmethod
+    def as_view(cls, view_type, *args, **kwargs):
+        return csrf_exempt(super(DjangoResource, cls).as_view(view_type, *args, **kwargs))
+
     def is_debug(self):
         # By default, Django-esque.
         return settings.DEBUG


### PR DESCRIPTION
For any custom endpoints that are not HTTP GET, csrf exemption
is needed or the call will fail with HTTP 403.

One might argue that this fix smells like someone wanting to implement rpc-like endpoints and one would not be necessarily wrong :) Nevertheless, API endpoints should not be protected with CSRF and this fix is consistent with `as_list` and `as_detail` methods.

I haven't written a test because FakeHTTPRequest does not trigger CSRF so it wasnt just a case of writing another test; if you find this pull request valid I would like to implement proper tests.
