### PR TITLE
fixed broken import in docs/extending.rst

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -374,7 +374,7 @@ up your code into a validation method. An example of this might look like...::
     from django.forms import ModelForm
 
     from restless.dj import DjangoResource
-    from restless.exceptions import HttpError
+    from restless.exceptions import BadRequest
 
 
     class UserForm(ModelForm):


### PR DESCRIPTION
I looked in the history and it looks like there was change from HttpError to BadRequest, but one import was still importing HttpError, this patch fixes it.
