### PR TITLE
Default to None for values which don't exist in lookup_data

### DIFF
--- a/restless/preparers.py
+++ b/restless/preparers.py
@@ -2,8 +2,8 @@ class Preparer(object):
     """
     A plain preparation object which just passes through data.
 
-    It also is relevant as the protocol subclasses should implement to work with
-    Restless.
+    It also is relevant as the protocol subclasses should implement to
+    work with Restless.
     """
     def __init__(self):
         super(Preparer, self).__init__()
@@ -41,8 +41,8 @@ class FieldsPreparer(Preparer):
 
     def prepare(self, data):
         """
-        Handles transforming the provided data into the fielded data that should
-        be exposed to the end user.
+        Handles transforming the provided data into the fielded data that
+        should be exposed to the end user.
 
         Uses the ``lookup_data`` method to traverse dotted paths.
 
@@ -51,6 +51,7 @@ class FieldsPreparer(Preparer):
         result = {}
 
         if not self.fields:
+
             # No fields specified. Serialize everything.
             return data
 
@@ -61,15 +62,16 @@ class FieldsPreparer(Preparer):
 
     def lookup_data(self, lookup, data):
         """
-        Given a lookup string, attempts to descend through nested data looking for
-        the value.
+        Given a lookup string, attempts to descend through nested data looking
+        for the value.
 
-        Can work with either dictionary-alikes or objects (or any combination of
-        those).
+        Can work with either dictionary-alikes or objects (or any combination
+        of those).
 
         Lookups should be a string. If it is a dotted path, it will be split on
-        ``.`` & it will traverse through to find the final value. If not, it will
-        simply attempt to find either a key or attribute of that name & return it.
+        ``.`` & it will traverse through to find the final value. If not, it
+        will simply attempt to find either a key or attribute of that name &
+        return it.
 
         Example::
 

--- a/restless/preparers.py
+++ b/restless/preparers.py
@@ -92,7 +92,10 @@ class FieldsPreparer(Preparer):
             'hello'
             >>> lookup_data('person.name', data)
             'daniel'
-
+            >>> lookup_data('greeting.se', data)
+            None
+            >>> lookup_data('idontexist', data)
+            None
         """
         value = data
         parts = lookup.split('.')
@@ -104,13 +107,15 @@ class FieldsPreparer(Preparer):
         remaining_lookup = '.'.join(parts[1:])
 
         if hasattr(data, 'keys') and hasattr(data, '__getitem__'):
-            # Dictionary enough for us.
-            value = data[part]
-        else:
-            # Assume it's an object.
-            value = getattr(data, part)
 
-        if not remaining_lookup:
+            # Dictionary enough for us.
+            value = data.get(part, None)
+        else:
+
+            # Assume it's an object.
+            value = getattr(data, part, None)
+
+        if not remaining_lookup or not value:
             return value
 
         # There's more to lookup, so dive in recursively.

--- a/tests/test_preparers.py
+++ b/tests/test_preparers.py
@@ -32,7 +32,7 @@ class LookupDataTestCase(unittest.TestCase):
                     awesome=True,
                     depth=3
                 ),
-            },
+            }
         }
 
     def test_dict_simple(self):
@@ -51,18 +51,21 @@ class LookupDataTestCase(unittest.TestCase):
         self.assertEqual(self.preparer.lookup_data('moof.buried.id', self.obj_data), 7)
         self.assertEqual(self.preparer.lookup_data('moof.buried.data.yes', self.obj_data), 'no')
 
+    def test_dict_nullable_fk(self):
+        self.assertEqual(self.preparer.lookup_data('more.this_does_not_exist', self.dict_data), None)
+
+    def test_obj_nullable_fk(self):
+        self.assertEqual(self.preparer.lookup_data('moof.this_does_not_exist', self.obj_data), None)
+
     def test_dict_miss(self):
-        with self.assertRaises(KeyError):
-            self.preparer.lookup_data('another', self.dict_data)
+        self.assertEqual(self.preparer.lookup_data('another', self.dict_data), None)
 
     def test_obj_miss(self):
-        with self.assertRaises(AttributeError):
-            self.preparer.lookup_data('whee', self.obj_data)
+        self.assertEqual(self.preparer.lookup_data('whee', self.obj_data), None)
 
     def test_empty_lookup(self):
         # We could possibly get here in the recursion.
         self.assertEqual(self.preparer.lookup_data('', 'Last value'), 'Last value')
 
     def test_complex_miss(self):
-        with self.assertRaises(AttributeError):
-            self.preparer.lookup_data('more.nested.nope', self.dict_data)
+        self.assertEquals(self.preparer.lookup_data('more.nested.nope', self.dict_data), None)


### PR DESCRIPTION
Basically an alternate solution to https://github.com/toastdriven/restless/pull/30

Erroring out of the loop of fields for lookup_data makes it hard to properly catch errors without overriding the entire prepare method (which is fine, but forces people to look at the source code (which is also fine haha)). The problem with this solution is that it does not fail so people will not know if they misspelled their fields, they will need to realize this based on the field they are looking for being ``null`` when it really shouldn't be.

My alternate solution (which I have yet to implement and is still brewing in my mind) is to be able to hook into the for loop in the prepare method so that errors to it could be handled on a per-field basis.
