### PR TITLE
Added a way to change the status header

### DIFF
--- a/restless/data.py
+++ b/restless/data.py
@@ -1,5 +1,5 @@
 class Data(object):
-    def __init__(self, value, should_prepare=True, prepare_with=None):
+    def __init__(self, value, should_prepare=True, prepare_with=None, status=None):
         """
         A container object that carries meta information about the data.
 
@@ -14,5 +14,6 @@ class Data(object):
         callable. Default is ``None`` (no custom callable).
         """
         self.value = value
+        self.status = status
         self.should_prepare = should_prepare
         self.prepare_with = prepare_with

--- a/restless/preparers.py
+++ b/restless/preparers.py
@@ -1,3 +1,6 @@
+from .data import Data
+
+
 class Preparer(object):
     """
     A plain preparation object which just passes through data.

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -428,8 +428,11 @@ class Resource(object):
 
         # Check for a ``Data``-like object. We should assume ``True`` (all
         # data gets prepared) unless it's explicitly marked as not.
-        if not getattr(data, 'should_prepare', True):
-            prepped_data = data.value
+        if isinstance(data, Data):
+            if not getattr(data, 'should_prepare', True):
+                prepped_data = data.value
+            else:
+                prepped_data = [self.prepare(item) for item in data.value]
         else:
             prepped_data = [self.prepare(item) for item in data]
 
@@ -451,8 +454,11 @@ class Resource(object):
 
         # Check for a ``Data``-like object. We should assume ``True`` (all
         # data gets prepared) unless it's explicitly marked as not.
-        if not getattr(data, 'should_prepare', True):
-            prepped_data = data.value
+        if isinstance(data, Data):
+            if not getattr(data, 'should_prepare', True):
+                prepped_data = data.value
+            else:
+                prepped_data = [self.prepare(item) for item in data.value]
         else:
             prepped_data = self.prepare(data)
 

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -428,11 +428,8 @@ class Resource(object):
 
         # Check for a ``Data``-like object. We should assume ``True`` (all
         # data gets prepared) unless it's explicitly marked as not.
-        if isinstance(data, Data):
-            if not getattr(data, 'should_prepare', True):
-                prepped_data = data.value
-            else:
-                prepped_data = [self.prepare(item) for item in data.value]
+        if not getattr(data, 'should_prepare', True):
+            prepped_data = data.value
         else:
             prepped_data = [self.prepare(item) for item in data]
 
@@ -454,11 +451,10 @@ class Resource(object):
 
         # Check for a ``Data``-like object. We should assume ``True`` (all
         # data gets prepared) unless it's explicitly marked as not.
-        if isinstance(data, Data):
-            if not getattr(data, 'should_prepare', True):
-                prepped_data = data.value
-            else:
-                prepped_data = [self.prepare(item) for item in data.value]
+        if hasattr(data, 'value') and not getattr(data, 'should_prepare', True):
+            prepped_data = data.value
+        elif hasattr(data, 'value'):
+            prepped_data = [self.prepare(item) for item in data.value]
         else:
             prepped_data = self.prepare(data)
 

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -15,8 +15,25 @@ def skip_prepare(func):
     """
     def _wrapper(self, *args, **kwargs):
         value = func(self, *args, **kwargs)
+        if isinstance(value, Data):
+            value.should_prepare = False
+            return value
         return Data(value, should_prepare=False)
     return _wrapper
+
+def status(status_code=200):
+    """
+    A convenience decorator for changing the status_code of a request.
+    """
+    def status_wrapper(func):
+        def _wrapper(self, *args, **kwargs):
+            value = func(self, *args, **kwargs)
+            if isinstance(value, Data):
+                value.status = status_code
+                return value
+            return Data(value, status=status_code)
+        return _wrapper
+    return status_wrapper
 
 
 class Resource(object):
@@ -295,7 +312,9 @@ class Resource(object):
         except Exception as err:
             return self.handle_error(err)
 
-        status = self.status_map.get(self.http_methods[endpoint][method], OK)
+        status = getattr(data, 'status', None)
+        if not status:
+            status = self.status_map.get(self.http_methods[endpoint][method], OK)
         return self.build_response(serialized, status=status)
 
     def handle_error(self, err):

--- a/tests/test_dj.py
+++ b/tests/test_dj.py
@@ -93,7 +93,7 @@ class DjTestResource(DjangoResource):
 
     @status(201)
     def changed_status(self):
-        return {}
+        return self.fake_db
 
     @skip_prepare
     def schema(self):
@@ -369,14 +369,38 @@ class DjangoResourceTestCase(unittest.TestCase):
             'title': 'Moved hosts'
         })
 
-    def test_changed_status_code(self):
+    def test_status_code_changed_with_models(self):
         status_endpoint = DjTestResource.as_view('changed_status')
         req = FakeHttpRequest('GET')
 
         resp = status_endpoint(req)
+        schema = json.loads(resp.content.decode('utf-8'))
+        print(schema)
         self.assertEqual(resp.status_code, 201)
+        self.assertEqual(json.loads(resp.content.decode('utf-8')),
+            [
+                {
+                    'author': 'daniel',
+                    'body': 'Hello world!',
+                    'id': 2,
+                    'title': 'First post'
+                },
+                {
+                    'author': 'daniel',
+                    'body': 'Stuff here.',
+                    'id': 4,
+                    'title': 'Another'
+                },
+                {
+                    'author': 'daniel',
+                    'body': "G'bye!",
+                    'id': 5,
+                    'title': 'Last'
+                }
+            ]
+        )
 
-    def test_changed_status_code(self):
+    def test_skipped_prepare_and_status_code_changed(self):
         status_and_schema_endpoint = DjTestResource.as_view('status_and_schema')
         req = FakeHttpRequest('GET')
 
@@ -386,7 +410,7 @@ class DjangoResourceTestCase(unittest.TestCase):
         schema = json.loads(resp.content.decode('utf-8'))
         self.assertEqual({'status': 'ok'}, schema)
 
-    def test_changed_status_code2(self):
+    def test_changed_status_code_and_skipped_prepare(self):
         status_and_schema2_endpoint = DjTestResource.as_view('status_and_schema2')
         req = FakeHttpRequest('GET')
 


### PR DESCRIPTION
I added a way to change the status code of a request.
Currently you have the following options:

- Add a decorator to a function: ```@status(201)```
- Create a data.Data object ```return data.Data('yourdata', status=201)


