### PR TITLE
Fix function __name__ when using skip_prepare and as_view

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import six
 import sys
 
@@ -132,6 +133,7 @@ class Resource(object):
 
         :returns: View function
         """
+        @wraps(cls)
         def _wrapper(request, *args, **kwargs):
             # Make a new instance so that no state potentially leaks between
             # instances.

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -14,6 +14,7 @@ def skip_prepare(func):
     """
     A convenience decorator for indicating the raw data should not be prepared.
     """
+    @wraps(func)
     def _wrapper(self, *args, **kwargs):
         value = func(self, *args, **kwargs)
         return Data(value, should_prepare=False)


### PR DESCRIPTION
When using the decorator `skip_prepare` and the function `as_view` we lost the function `__name__`, it pass to be `_wrapper`. Using `functools.wraps` fixes this error.
