### PR TITLE
DjangoResource updates to support non-numeric primary keys

### DIFF
--- a/restless/dj.py
+++ b/restless/dj.py
@@ -17,14 +17,16 @@ class DjangoResource(Resource):
     Doesn't require any special configuration, but helps when working in a
     Django environment.
     """
+    PRIMARY_KEY_PATTERN = '\d+'
+
     # Because Django.
     @classmethod
-    def as_list(self, *args, **kwargs):
-        return csrf_exempt(super(DjangoResource, self).as_list(*args, **kwargs))
+    def as_list(cls, *args, **kwargs):
+        return csrf_exempt(super(DjangoResource, cls).as_list(*args, **kwargs))
 
     @classmethod
-    def as_detail(self, *args, **kwargs):
-        return csrf_exempt(super(DjangoResource, self).as_detail(*args, **kwargs))
+    def as_detail(cls, *args, **kwargs):
+        return csrf_exempt(super(DjangoResource, cls).as_detail(*args, **kwargs))
 
     def is_debug(self):
         # By default, Django-esque.
@@ -86,5 +88,9 @@ class DjangoResource(Resource):
         """
         return patterns('',
             url(r'^$', cls.as_list(), name=cls.build_url_name('list', name_prefix)),
-            url(r'^(?P<pk>\d+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
+            url(
+                r'^(?P<pk>{})/$'.format(cls.PRIMARY_KEY_PATTERN),
+                cls.as_detail(),
+                name=cls.build_url_name('detail', name_prefix)
+            ),
         )


### PR DESCRIPTION
Updates `DjangoResource` to allow subclasses to override the primary key pattern, in case of non-numeric primary keys (hashes, UUIDs).

Also updates self -> cls on two `@classmethod` definitions.
