### PR TITLE
Make args and kwargs available on Resource

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -78,6 +78,8 @@ class Resource(object):
         self.request = None
         self.data = None
         self.endpoint = None
+        self.args = []
+        self.kwargs = {}
         self.status = 200
 
     @classmethod
@@ -137,7 +139,9 @@ class Resource(object):
             # instances.
             inst = cls(*init_args, **init_kwargs)
             inst.request = request
-            return inst.handle(view_type, *args, **kwargs)
+            inst.args = args
+            inst.kwargs = kwargs
+            return inst.handle(view_type)
 
         return _wrapper
 
@@ -290,7 +294,7 @@ class Resource(object):
 
             self.data = self.deserialize(method, endpoint, self.request_body())
             view_method = getattr(self, self.http_methods[endpoint][method])
-            data = view_method(*args, **kwargs)
+            data = view_method(*self.args, **self.kwargs)
             serialized = self.serialize(method, endpoint, data)
         except Exception as err:
             return self.handle_error(err)


### PR DESCRIPTION
Sometimes you need access to args and kwargs outside of the view method. e.g. in resource.deserialize(), resource.serialize() or resource.is_authenticated()

Is this something you would consider merging? If so I can look into tests, if this breaks them or they need extending to cover this.
