### PR TITLE
Setting 'Content-Type: text/plain' for 204 No Content responses

### DIFF
--- a/restless/dj.py
+++ b/restless/dj.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse, Http404
 from django.views.decorators.csrf import csrf_exempt
 
+from .constants import OK, NO_CONTENT
 from .exceptions import NotFound
 from .resources import Resource
 
@@ -30,9 +31,14 @@ class DjangoResource(Resource):
         # By default, Django-esque.
         return settings.DEBUG
 
-    def build_response(self, data, status=200):
+    def build_response(self, data, status=OK):
         # By default, Django-esque.
-        resp = HttpResponse(data, content_type='application/json')
+        if status == NO_CONTENT:
+            # Avoid crashing the client when it tries to parse nonexisting JSON.
+            content_type = 'text/plain'
+        else:
+            content_type = 'application/json'
+        resp = HttpResponse(data, content_type=content_type)
         resp.status_code = status
         return resp
 

--- a/restless/fl.py
+++ b/restless/fl.py
@@ -1,6 +1,7 @@
 from flask import make_response
 from flask import request
 
+from .constants import OK, NO_CONTENT
 from .resources import Resource
 
 
@@ -44,9 +45,14 @@ class FlaskResource(Resource):
         from flask import current_app
         return current_app.debug
 
-    def build_response(self, data, status=200):
+    def build_response(self, data, status=OK):
+        if status == NO_CONTENT:
+            # Avoid crashing the client when it tries to parse nonexisting JSON.
+            content_type = 'text/plain'
+        else:
+            content_type = 'application/json'
         return make_response(data, status, {
-            'Content-Type': 'application/json'
+            'Content-Type': content_type,
         })
 
     @classmethod

--- a/restless/it.py
+++ b/restless/it.py
@@ -1,6 +1,8 @@
 import re
 
 import itty
+
+from restless.constants import OK, NO_CONTENT
 from restless.resources import Resource
 
 
@@ -16,8 +18,13 @@ class IttyResource(Resource):
     def is_debug(self):
         return self.debug
 
-    def build_response(self, data, status=200):
-        return itty.Response(data, status=status, content_type='application/json')
+    def build_response(self, data, status=OK):
+        if status == NO_CONTENT:
+            # Avoid crashing the client when it tries to parse nonexisting JSON.
+            content_type = 'text/plain'
+        else:
+            content_type = 'application/json'
+        return itty.Response(data, status=status, content_type=content_type)
 
     @classmethod
     def setup_urls(cls, rule_prefix):

--- a/restless/pyr.py
+++ b/restless/pyr.py
@@ -1,6 +1,8 @@
 from pyramid.response import Response
 
+from .constants import OK, NO_CONTENT
 from .resources import Resource
+
 
 class PyramidResource(Resource):
     """
@@ -26,8 +28,13 @@ class PyramidResource(Resource):
 
         return _wrapper
 
-    def build_response(self, data, status=200):
-        resp = Response(data, status_code=status, content_type="application/json")
+    def build_response(self, data, status=OK):
+        if status == NO_CONTENT:
+            # Avoid crashing the client when it tries to parse nonexisting JSON.
+            content_type = 'text/plain'
+        else:
+            content_type = 'application/json'
+        resp = Response(data, status_code=status, content_type=content_type)
         return resp
 
     @classmethod

--- a/restless/tnd.py
+++ b/restless/tnd.py
@@ -1,5 +1,5 @@
 from tornado import web, gen
-from .constants import OK
+from .constants import OK, NO_CONTENT
 from .resources import Resource
 from .exceptions import MethodNotImplemented, Unauthorized
 
@@ -128,8 +128,14 @@ class TornadoResource(Resource):
     def request_body(self):
         return self.request.body 
 
-    def build_response(self, data, status=200):
-        self.ref_rh.set_header("Content-Type", "application/json; charset=UTF-8")
+    def build_response(self, data, status=OK):
+        if status == NO_CONTENT:
+            # Avoid crashing the client when it tries to parse nonexisting JSON.
+            content_type = 'text/plain'
+        else:
+            content_type = 'application/json'
+        self.ref_rh.set_header("Content-Type", "{}; charset=UTF-8"
+                               .format(content_type))
 
         self.ref_rh.set_status(status)
         self.ref_rh.finish(data)


### PR DESCRIPTION
This fixes a common issue with AJAX client libraries, which happens when they send a DELETE request and try to parse a JSON on the response because of its `Content-Type`.

Yes, the clients are not handling 204 responses correctly, but it helps to mitigate this kind of issue.