### PR TITLE
tox-based build matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tests/htmlcov
 .coverage
 htmlcov
 *.egg-info
+.cache/
+.eggs/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - "3.5"
-  - "3.3"
+  - "3.4"
   - "2.7"
   - "pypy"
   - "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
 language: python
 
 python:
-  - "3.4"
+  - "3.5"
   - "3.3"
   - "2.7"
+  - "pypy"
+  - "pypy3"
 
 # command to install dependencies
 install:
-    - pip install -r test${TRAVIS_PYTHON_VERSION:0:1}_requirements.txt
-    - pip install coveralls
+    - pip install tox-travis
 
 # command to run tests
 script:
-    - py.test --cov=restless
-
-# command to notify coveralls
-after_success:
-    - coveralls
+    - tox

--- a/README.rst
+++ b/README.rst
@@ -148,4 +148,15 @@ BSD
 Running the Tests
 =================
 
-Just run `tox`.
+The test suite uses `tox` for simultaneous support of multiple versions of both
+Python and Django. The current versions of Python supported are:
+
+* CPython 2.7
+* CPython 3.4
+* CPython 3.5
+* PyPy (Python 2.7)
+* PyPy3 (Python 3.2)
+* PyPy3 beta (Python 3.3)
+
+You just need to install the Python interpreters above and the `tox` package
+(available via `pip`), then run the `tox` command.

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,8 @@
 restless
 ========
 
-.. image:: https://travis-ci.org/toastdriven/restless.png?branch=master
-        :target: https://travis-ci.org/toastdriven/restless
-.. image:: https://coveralls.io/repos/toastdriven/restless/badge.png
-        :target: https://coveralls.io/r/toastdriven/restless
+.. image:: https://travis-ci.org/CraveFood/restless.png?branch=master
+        :target: https://travis-ci.org/CraveFood/restless
 
 A lightweight REST miniframework for Python.
 
@@ -150,24 +148,4 @@ BSD
 Running the Tests
 =================
 
-Getting the tests running looks like:
-
-.. code:: sh
-
-    $ virtualenv -p python3 env3
-    $ . env3/bin/activate
-    $ pip install -r test3_requirements.txt
-    $ export PYTHONPATH=`pwd`
-    $ py.test -s -v --cov=restless --cov-report=html tests
-
-For Python 2:
-
-.. code:: sh
-
-    $ virtualenv env2
-    $ . env2/bin/activate
-    $ pip install -r test2_requirements.txt
-    $ export PYTHONPATH=`pwd`
-    $ py.test -s -v --cov=restless --cov-report=html tests
-
-Coverage is at about 94%, so please don't make it worse. :D
+Just run `tox`.

--- a/test2_requirements.txt
+++ b/test2_requirements.txt
@@ -1,3 +1,0 @@
--r test3_requirements.txt
-
-itty==0.8.2

--- a/test3_requirements.txt
+++ b/test3_requirements.txt
@@ -1,8 +1,0 @@
-six>=1.4.0
-pytest==2.5.2
-pytest-cov==1.6
-Django==1.6.1
-Flask==0.10.1
-pyramid==1.4.5
-tornado==3.2.2
-

--- a/tests/test_dj.py
+++ b/tests/test_dj.py
@@ -1,13 +1,18 @@
 import unittest
 
-from django.http import Http404
-from django.core.exceptions import ObjectDoesNotExist
+try:
+    from django.http import Http404
+    from django.core.exceptions import ObjectDoesNotExist
 
-# Ugh. Settings for Django.
-from django.conf import settings
-settings.configure(DEBUG=True)
+    # Ugh. Settings for Django.
+    from django.conf import settings
+    settings.configure(DEBUG=True)
 
-from restless.dj import DjangoResource
+    from restless.dj import DjangoResource
+except ImportError:
+    settings = None
+    DjangoResource = object
+
 from restless.exceptions import Unauthorized
 from restless.preparers import FieldsPreparer
 from restless.resources import skip_prepare
@@ -125,6 +130,7 @@ class DjTestResourceHttp404Handling(DjTestResource):
         raise Http404("Model with pk {0} not found.".format(pk))
 
 
+@unittest.skipIf(not settings, "Django is not available")
 class DjangoResourceTestCase(unittest.TestCase):
     def setUp(self):
         super(DjangoResourceTestCase, self).setUp()

--- a/tests/test_fl.py
+++ b/tests/test_fl.py
@@ -1,9 +1,13 @@
 import unittest
 
-# Ugh. Globals for Flask.
-import flask
+try:
+    # Ugh. Globals for Flask.
+    import flask
+    from restless.fl import FlaskResource
+except ImportError:
+    flask = None
+    FlaskResource = object
 
-from restless.fl import FlaskResource
 from restless.utils import json
 
 from .fakes import FakeHttpRequest
@@ -32,6 +36,7 @@ class FlTestResource(FlaskResource):
         self.fake_db.append(self.data)
 
 
+@unittest.skipIf(not flask, 'Flask is not available')
 class FlaskResourceTestCase(unittest.TestCase):
     def setUp(self):
         super(FlaskResourceTestCase, self).setUp()

--- a/tests/test_pyr.py
+++ b/tests/test_pyr.py
@@ -1,8 +1,12 @@
 import unittest
 
-from pyramid import testing
+try:
+    from pyramid import testing
+    from restless.pyr import PyramidResource
+except ImportError:
+    testing = None
+    PyramidResource = object
 
-from restless.pyr import PyramidResource
 from restless.utils import json
 
 from .fakes import FakeHttpRequest, FakeHttpResponse
@@ -36,6 +40,8 @@ class PyrTestResource(PyramidResource):
 
         return True
 
+
+@unittest.skipIf(not testing, 'Pyramid is not available')
 class PyramidResourceTestCase(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py{27,34,35,py2,py32,py33}-{dj18,dj19,pyramid,tornado},
-          py{27,34,35,py2}-flask
+envlist = py{27,34,35,py2,py32,py33}-{dj18,dj19}
 
 [testenv]
 basepython =
@@ -13,11 +12,11 @@ basepython =
 deps =
     pytest
     pytest-cov
+    py{27,34,35,py2}: Flask
+    Pyramid
+    tornado
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
-    flask: Flask
-    pyramid: Pyramid
-    tornado: tornado
 commands =
     py.test --cov=restless
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{27,34,35,py27,py32,py33}-{dj18,dj19,pyramid,tornado},
-          py{27,34,35,py27}-flask
+envlist = py{27,34,35,py2,py32,py33}-{dj18,dj19,pyramid,tornado},
+          py{27,34,35,py2}-flask
 
 [testenv]
 basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
-    pypy27: pypy2.7
+    pypy2: pypy
     pypy32: pypy3.2
     pypy33: pypy3.3
 deps =
@@ -25,5 +25,5 @@ commands =
 2.7 = py27
 3.4 = py34
 3.5 = py35
-pypy = pypy27
+pypy = pypy2
 pypy3 = pypy32

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist = py{27,34,35,py27,py32,py33}-{dj18,dj19,pyramid,tornado},
+          py{27,34,35,py27}-flask
+
+[testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    pypy27: pypy2.7
+    pypy32: pypy3.2
+    pypy33: pypy3.3
+deps =
+    pytest
+    pytest-cov
+    dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
+    flask: Flask
+    pyramid: Pyramid
+    tornado: tornado
+commands =
+    py.test --cov=restless
+
+[tox:travis]
+2.7 = py27
+3.4 = py34
+3.5 = py35
+pypy = pypy27
+pypy3 = pypy32


### PR DESCRIPTION
Cross-testing for Python 2.7, 3.4, 3.5, PyPy, PyPy3 stable and PyPy3 beta, plus skipping tests for uninstalled web frameworks.

Closes #66 as well, since it's built to use the newest version of Tornado.
