### PR TITLE
Allow PKs with dashes and alphanumeric digits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,15 +130,15 @@ Hooking it up:
 .. code:: python
 
     # api/urls.py
-    from django.conf.urls.default import url, patterns, include
+    from django.conf.urls.default import url, include
 
     from posts.api import PostResource
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The usual suspects, then...
 
         url(r'^api/posts/', include(PostResource.urls())),
-    )
+    ]
 
 
 Licence

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -92,7 +92,7 @@ Finally, it's just a matter of hooking up the URLs as well. You can do this
 manually or (once again) by extending a built-in method.::
 
     # Add the correct import here.
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 
     from restless.dj import DjangoResource
     from restless.resources import skip_prepare
@@ -128,9 +128,9 @@ manually or (once again) by extending a built-in method.::
         @classmethod
         def urls(cls, name_prefix=None):
             urlpatterns = super(PostResource, cls).urls(name_prefix=name_prefix)
-            return urlpatterns + patterns('',
+            return urlpatterns + [
                 url(r'^schema/$', cls.as_view('schema'), name=cls.build_url_name('schema', name_prefix)),
-            )
+            ]
 
 .. note::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -252,17 +252,17 @@ practice would be to create a URLconf just for the API portion of your site.::
 
     # The ``settings.ROOT_URLCONF`` file
     # myproject/urls.py
-    from django.conf.urls import patterns, url, include
+    from django.conf.urls import url, include
 
     # Add this!
     from posts.api import PostResource
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The usual fare, then...
 
         # Add this!
         url(r'api/posts/', include(PostResource.urls())),
-    )
+    ]
 
 Note that unlike some other CBVs (admin specifically), the ``urls`` here is a
 **METHOD**, not an attribute/property. Those parens are important!
@@ -272,13 +272,13 @@ Manual URLconfs
 
 You can also manually hook up URLs by specifying something like::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # ...
 
         # Identical to the above.
         url(r'api/posts/$', PostResource.as_list(), name='api_post_list'),
         url(r'api/posts/(?P<pk>\d+)/$', PostResource.as_detail(), name='api_post_detail'),
-    )
+    ]
 
 
 Testing the API

--- a/examples/django/posts/urls.py
+++ b/examples/django/posts/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from .api import PostResource
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^posts/', include(PostResource.urls())),
 
     # Alternatively, if you don't like the defaults...
     # url(r'^posts/$', PostResource.as_list(), name='api_posts_list'),
     # url(r'^posts/(?P<pk>\d+)/$', PostResource.as_detail(), name='api_posts_detail'),
-)
+]

--- a/restless/dj.py
+++ b/restless/dj.py
@@ -1,7 +1,7 @@
 import six
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse, Http404
 from django.views.decorators.csrf import csrf_exempt

--- a/restless/dj.py
+++ b/restless/dj.py
@@ -82,9 +82,9 @@ class DjangoResource(Resource):
             ``api_blogpost_list``
         :type name_prefix: string
 
-        :returns: A ``patterns`` object for ``include(...)``
+        :returns: A list of ``url`` objects for ``include(...)``
         """
-        return patterns('',
+        return [
             url(r'^$', cls.as_list(), name=cls.build_url_name('list', name_prefix)),
             url(r'^(?P<pk>[\w-]+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
-        )
+        ]

--- a/restless/dj.py
+++ b/restless/dj.py
@@ -86,5 +86,5 @@ class DjangoResource(Resource):
         """
         return patterns('',
             url(r'^$', cls.as_list(), name=cls.build_url_name('list', name_prefix)),
-            url(r'^(?P<pk>\d+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
+            url(r'^(?P<pk>[\w-]+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
         )

--- a/restless/it.py
+++ b/restless/it.py
@@ -30,7 +30,7 @@ class IttyResource(Resource):
         :returns: ``None``
         """
         list_url = "%s" % itty.add_slash(rule_prefix)
-        detail_url = "%s" % itty.add_slash(rule_prefix + "/(?P<pk>\d+)")
+        detail_url = "%s" % itty.add_slash(rule_prefix + "/(?P<pk>[\w-]+)")
 
         list_re = re.compile("^%s$" % list_url)
         detail_re = re.compile("^%s$" % detail_url)

--- a/tests/test_dj.py
+++ b/tests/test_dj.py
@@ -38,16 +38,20 @@ class DjTestResource(DjangoResource):
         # Just for testing.
         self.__class__.fake_db = [
             FakeModel(
-                id=2,
+                id='dead-beef',
                 title='First post',
                 username='daniel',
                 content='Hello world!'),
             FakeModel(
-                id=4,
+                id='de-faced',
                 title='Another',
                 username='daniel',
                 content='Stuff here.'),
-            FakeModel(id=5, title='Last', username='daniel', content="G'bye!"),
+            FakeModel(
+                id='bad-f00d',
+                title='Last',
+                username='daniel',
+                content="G'bye!"),
         ]
 
     def is_authenticated(self):
@@ -144,19 +148,19 @@ class DjangoResourceTestCase(unittest.TestCase):
                 {
                     'author': 'daniel',
                     'body': 'Hello world!',
-                    'id': 2,
+                    'id': 'dead-beef',
                     'title': 'First post'
                 },
                 {
                     'author': 'daniel',
                     'body': 'Stuff here.',
-                    'id': 4,
+                    'id': 'de-faced',
                     'title': 'Another'
                 },
                 {
                     'author': 'daniel',
                     'body': "G'bye!",
-                    'id': 5,
+                    'id': 'bad-f00d',
                     'title': 'Last'
                 }
             ]
@@ -166,13 +170,13 @@ class DjangoResourceTestCase(unittest.TestCase):
         detail_endpoint = DjTestResource.as_detail()
         req = FakeHttpRequest('GET')
 
-        resp = detail_endpoint(req, 4)
+        resp = detail_endpoint(req, 'de-faced')
         self.assertEqual(resp['Content-Type'], 'application/json')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json.loads(resp.content.decode('utf-8')), {
             'author': 'daniel',
             'body': 'Stuff here.',
-            'id': 4,
+            'id': 'de-faced',
             'title': 'Another'
         })
 

--- a/tests/test_fl.py
+++ b/tests/test_fl.py
@@ -15,9 +15,9 @@ class FlTestResource(FlaskResource):
     def fake_init(self):
         # Just for testing.
         self.__class__.fake_db = [
-            {"id": 2, "title": 'First post'},
-            {"id": 4, "title": 'Another'},
-            {"id": 5, "title": 'Last'},
+            {"id": 'dead-beef', "title": 'First post'},
+            {"id": 'de-faced', "title": 'Another'},
+            {"id": 'bad-f00d', "title": 'Last'},
         ]
 
     def list(self):
@@ -54,15 +54,15 @@ class FlaskResourceTestCase(unittest.TestCase):
             self.assertEqual(json.loads(resp.data.decode('utf-8')), {
                 'objects': [
                     {
-                        'id': 2,
+                        'id': 'dead-beef',
                         'title': 'First post'
                     },
                     {
-                        'id': 4,
+                        'id': 'de-faced',
                         'title': 'Another'
                     },
                     {
-                        'id': 5,
+                        'id': 'bad-f00d',
                         'title': 'Last'
                     }
                 ]
@@ -73,11 +73,11 @@ class FlaskResourceTestCase(unittest.TestCase):
         flask.request = FakeHttpRequest('GET')
 
         with self.app.test_request_context('/whatever/', method='GET'):
-            resp = detail_endpoint(4)
+            resp = detail_endpoint('de-faced')
             self.assertEqual(resp.headers['Content-Type'], 'application/json')
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(json.loads(resp.data.decode('utf-8')), {
-                'id': 4,
+                'id': 'de-faced',
                 'title': 'Another'
             })
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -18,9 +18,9 @@ class ItTestResource(IttyResource):
     def fake_init(self):
         # Just for testing.
         self.__class__.fake_db = [
-            {"id": 2, "title": 'First post'},
-            {"id": 4, "title": 'Another'},
-            {"id": 5, "title": 'Last'},
+            {"id": 'dead-beef', "title": 'First post'},
+            {"id": 'de-faced', "title": 'Another'},
+            {"id": 'bad-f00d', "title": 'Last'},
         ]
 
     def list(self):
@@ -54,15 +54,15 @@ class IttyResourceTestCase(unittest.TestCase):
         self.assertEqual(json.loads(resp.output), {
             'objects': [
                 {
-                    'id': 2,
+                    'id': 'dead-beef',
                     'title': 'First post'
                 },
                 {
-                    'id': 4,
+                    'id': 'de-faced',
                     'title': 'Another'
                 },
                 {
-                    'id': 5,
+                    'id': 'bad-f00d',
                     'title': 'Last'
                 }
             ]
@@ -72,11 +72,11 @@ class IttyResourceTestCase(unittest.TestCase):
         detail_endpoint = ItTestResource.as_detail()
         request = FakeHttpRequest('GET')
 
-        resp = detail_endpoint(request, 4)
+        resp = detail_endpoint(request, 'de-faced')
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.status, 200)
         self.assertEqual(json.loads(resp.output), {
-            'id': 4,
+            'id': 'de-faced',
             'title': 'Another'
         })
 
@@ -105,4 +105,5 @@ class IttyResourceTestCase(unittest.TestCase):
         self.assertEqual(len(itty.REQUEST_MAPPINGS['PUT']), 2)
         self.assertEqual(len(itty.REQUEST_MAPPINGS['DELETE']), 2)
         self.assertEqual(itty.REQUEST_MAPPINGS['GET'][0][1], '/test/')
-        self.assertEqual(itty.REQUEST_MAPPINGS['GET'][1][1], '/test/(?P<pk>\\d+)/')
+        self.assertEqual(itty.REQUEST_MAPPINGS['GET'][1][1],
+                         '/test/(?P<pk>[\\w-]+)/')

--- a/tests/test_pyr.py
+++ b/tests/test_pyr.py
@@ -14,9 +14,9 @@ class PyrTestResource(PyramidResource):
     def fake_init(self):
         # Just for testing.
         self.__class__.fake_db = [
-            {"id": 2, "title": 'First post'},
-            {"id": 4, "title": 'Another'},
-            {"id": 5, "title": 'Last'},
+            {"id": "dead-beef", "title": 'First post'},
+            {"id": "de-faced", "title": 'Another'},
+            {"id": "bad-f00d", "title": 'Last'},
         ]
 
     def list(self):
@@ -51,15 +51,15 @@ class PyramidResourceTestCase(unittest.TestCase):
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
             'objects': [
                 {
-                    'id': 2,
+                    'id': 'dead-beef',
                     'title': 'First post'
                 },
                 {
-                    'id': 4,
+                    'id': 'de-faced',
                     'title': 'Another'
                 },
                 {
-                    'id': 5,
+                    'id': 'bad-f00d',
                     'title': 'Last'
                 }
             ]
@@ -70,13 +70,13 @@ class PyramidResourceTestCase(unittest.TestCase):
         req = testing.DummyRequest()
 
         req = FakeHttpRequest('GET')
-        req.matchdict = {'name': 4}
+        req.matchdict = {'name': 'de-faced'}
 
         resp = detail_endpoint(req)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
-            'id': 4,
+            'id': 'de-faced',
             'title': 'Another'
         })
 

--- a/tests/test_tnd.py
+++ b/tests/test_tnd.py
@@ -15,9 +15,9 @@ class TndBaseTestResource(TornadoResource):
     def __init__(self):
         # Just for testing.
         self.__class__.fake_db = [
-            {"id": 2, "title": 'First post'},
-            {"id": 4, "title": 'Another'},
-            {"id": 5, "title": 'Last'},
+            {"id": "dead-beef", "title": 'First post'},
+            {"id": "de-faced", "title": 'Another'},
+            {"id": "bad-f00d", "title": 'Last'},
         ]
 
 
@@ -30,7 +30,7 @@ class TndBasicTestResource(TndBaseTestResource):
 
     def detail(self, pk):
         for item in self.fake_db:
-            if item['id'] == int(pk):
+            if item['id'] == pk:
                 return item
         return None
 
@@ -49,7 +49,7 @@ class TndAsyncTestResource(TndBaseTestResource):
     @gen.coroutine
     def detail(self, pk):
         for item in self.fake_db:
-            if item['id'] == int(pk):
+            if item['id'] == pk:
                 raise gen.Return(item)
         raise gen.Return(None)
 
@@ -88,15 +88,15 @@ class TndResourceTestCase(BaseHTTPTestCase):
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
             'objects': [
                 {
-                    'id': 2,
+                    'id': 'dead-beef',
                     'title': 'First post'
                 },
                 {
-                    'id': 4,
+                    'id': 'de-faced',
                     'title': 'Another'
                 },
                 {
-                    'id': 5,
+                    'id': 'bad-f00d',
                     'title': 'Last'
                 }
             ]
@@ -104,14 +104,14 @@ class TndResourceTestCase(BaseHTTPTestCase):
 
     def test_as_detail(self):
         resp = self.fetch(
-            '/fake/4',
+            '/fake/de-faced',
             method='GET',
             follow_redirects=False
         )
         self.assertEqual(resp.headers['Content-Type'], 'application/json; charset=UTF-8')
         self.assertEqual(resp.code, 200)
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
-            'id': 4,
+            'id': 'de-faced',
             'title': 'Another'
         })
 
@@ -237,15 +237,15 @@ class TndAsyncResourceTestCase(BaseHTTPTestCase):
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
             'objects': [
                 {
-                    'id': 2,
+                    'id': 'dead-beef',
                     'title': 'First post'
                 },
                 {
-                    'id': 4,
+                    'id': 'de-faced',
                     'title': 'Another'
                 },
                 {
-                    'id': 5,
+                    'id': 'bad-f00d',
                     'title': 'Last'
                 }
             ]
@@ -253,14 +253,14 @@ class TndAsyncResourceTestCase(BaseHTTPTestCase):
 
     def test_as_detail(self):
         resp = self.fetch(
-            '/fake_async/4',
+            '/fake_async/de-faced',
             method='GET',
             follow_redirects=False
         )
         self.assertEqual(resp.headers['Content-Type'], 'application/json; charset=UTF-8')
         self.assertEqual(resp.code, 200)
         self.assertEqual(json.loads(resp.body.decode('utf-8')), {
-            'id': 4,
+            'id': 'de-faced',
             'title': 'Another'
         })
 


### PR DESCRIPTION
This way they can be hex numbers, UUIDs, slugs and so on.

Closes #77.
