### PR TITLE
Severed last ties between Resource and Django

### DIFF
--- a/restless/dj.py
+++ b/restless/dj.py
@@ -27,11 +27,9 @@ class DjangoResource(Resource):
         return csrf_exempt(super(DjangoResource, self).as_detail(*args, **kwargs))
 
     def is_debug(self):
-        # By default, Django-esque.
         return settings.DEBUG
 
     def build_response(self, data, status=200):
-        # By default, Django-esque.
         resp = HttpResponse(data, content_type='application/json')
         resp.status_code = status
         return resp

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -4,7 +4,7 @@ import sys
 from .constants import OK, CREATED, ACCEPTED, NO_CONTENT
 from .data import Data
 from .exceptions import MethodNotImplemented, Unauthorized
-from .preparers import Preparer, FieldsPreparer
+from .preparers import Preparer
 from .serializers import JSONSerializer
 from .utils import format_traceback
 
@@ -145,9 +145,8 @@ class Resource(object):
         """
         Returns the HTTP method for the current request.
 
-        The default implementation is Django-specific, so if you're integrating
-        with a new web framework, you'll need to override this method within
-        your subclass.
+        If you're integrating with a new web framework, you might need to
+        override this method within your subclass.
 
         :returns: The HTTP method in uppercase
         :rtype: string
@@ -161,9 +160,8 @@ class Resource(object):
 
         Useful for deserializing the content the user sent (typically JSON).
 
-        The default implementation is Django-specific, so if you're integrating
-        with a new web framework, you'll need to override this method within
-        your subclass.
+        If you're integrating with a new web framework, you might need to
+        override this method within your subclass.
 
         :returns: The body of the request
         :rtype: string
@@ -175,9 +173,8 @@ class Resource(object):
         """
         Given some data, generates an HTTP response.
 
-        The default implementation is Django-specific, so if you're integrating
-        with a new web framework, you'll need to override this method within
-        your subclass.
+        If you're integrating with a new web framework, you **MUST**
+        override this method within your subclass.
 
         :param data: The body of the response to send
         :type data: string
@@ -188,13 +185,7 @@ class Resource(object):
 
         :returns: A response object
         """
-        # TODO: Remove the Django.
-        #       This should be plain old WSGI by default, if possible.
-        # By default, Django-esque.
-        from django.http import HttpResponse
-        resp = HttpResponse(data, content_type='application/json')
-        resp.status_code = status
-        return resp
+        raise NotImplementedError()
 
     def build_error(self, err):
         """

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,9 +9,7 @@ from restless.utils import json
 from .fakes import FakeHttpRequest, FakeHttpResponse
 
 
-class NonDjangoResource(Resource):
-    # Because the default implementation is a tiny-bit Django-specific,
-    # we're faking some things here.
+class GenericResource(Resource):
     def build_response(self, data, status=200):
         resp = FakeHttpResponse(data, content_type='application/json')
         resp.status_code = status
@@ -21,11 +19,11 @@ class NonDjangoResource(Resource):
     def is_authenticated(self):
         if self.endpoint == 'list':
             return False
-        return super(NonDjangoResource, self).is_authenticated()
+        return super(GenericResource, self).is_authenticated()
 
 
 class ResourceTestCase(unittest.TestCase):
-    resource_class = NonDjangoResource
+    resource_class = GenericResource
 
     def setUp(self):
         super(ResourceTestCase, self).setUp()


### PR DESCRIPTION
`build_response` now throws a `NotImplementedError` by default, while `request_method` and `request_body` are not called "Django-specific" on the documentation since multiple subclasses use them as-is.

Making it pure WSGI by default would need a separate `Resource` (hint!), since it needs to wrap the entire request-response cycle.
