### PR TITLE
Default build_error() allows any serializable object as message

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -208,7 +208,7 @@ class Resource(object):
         :returns: A response object
         """
         data = {
-            'error': six.text_type(err),
+            'error': err.message,
         }
 
         if self.is_debug():

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -208,7 +208,7 @@ class Resource(object):
         :returns: A response object
         """
         data = {
-            'error': err.message,
+            'error': err.args[0],
         }
 
         if self.is_debug():

--- a/tests/test_dj.py
+++ b/tests/test_dj.py
@@ -80,7 +80,10 @@ class DjTestResource(DjangoResource):
                     return
 
     def create_detail(self):
-        raise ValueError("This is a random & crazy exception.")
+        raise ValueError({
+            'code': 'random-crazy',
+            'message': 'This is a random & crazy exception.',
+        })
 
     @skip_prepare
     def schema(self):
@@ -252,7 +255,10 @@ class DjangoResourceTestCase(unittest.TestCase):
         self.assertEqual(resp['Content-Type'], 'application/json')
         self.assertEqual(resp.status_code, 500)
         self.assertEqual(json.loads(resp.content.decode('utf-8')), {
-            'error': 'This is a random & crazy exception.'
+            'error': {
+                'code': 'random-crazy',
+                'message': 'This is a random & crazy exception.',
+            }
         })
 
     def test_object_does_not_exist(self):


### PR DESCRIPTION
Error messages should not be constrained to strings - the client application often benefits for extra data, such as error codes or model fields involved.
This allows for any object sent on an exception to be returned to the user.

Closes #32.
