### PR TITLE
Removed py3.3 from django 1.9 and 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,18 @@ python:
   - "pypy"
   - "pypy3"
 
+env:
+  - DJANGO=1.8
+  - DJANGO=1.9
+  - DJANGO=1.10
+  
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO=1.9
+    - python: "3.3"
+      env: DJANGO=1.10
+
 # command to install dependencies
 install:
     - pip install tox-travis


### PR DESCRIPTION
According to this [link](https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django), Django +1.9 will not support python 3.3. 

I removed the test of the Django +1.9 on python 3.3 on travis file