### PR TITLE
Limit Pyramid and WebOb versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ deps =
     pytest
     pytest-cov
     py{27,34,35,py2}: Flask
-    Pyramid
+    WebOb>=1.3.1,<1.7
+    Pyramid<1.8
     tornado
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10


### PR DESCRIPTION
Pyramid 1.8 requires WebOb>=1.7 which is currently not supported by us