### PR TITLE
Fix unset charset with Pyramid / WebOb

### DIFF
--- a/restless/pyr.py
+++ b/restless/pyr.py
@@ -1,3 +1,5 @@
+import six
+
 from pyramid.response import Response
 
 from .constants import OK, NO_CONTENT
@@ -34,7 +36,12 @@ class PyramidResource(Resource):
             content_type = 'text/plain'
         else:
             content_type = 'application/json'
-        resp = Response(data, status_code=status, content_type=content_type)
+
+        if six.PY3:
+            resp = Response(text=data, status_code=status, content_type=content_type)
+        else:
+            resp = Response(data, status_code=status, content_type=content_type)
+
         return resp
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     six
     pytest
     pytest-cov
-    WebOb>=1.3.1,<1.7
-    Pyramid<1.8
+    WebOb>=1.7,<1.8
+    Pyramid<1.10
     tornado
     py{27,33,34,35}: Flask>=0.10
     dj18: Django>=1.8,<1.9


### PR DESCRIPTION
Response no longer treats `application/json` as a special case that
may also be treated as text.

https://docs.pylonsproject.org/projects/webob/en/stable/whatsnew-1.7.html