### PR TITLE
Added `Resource.prepare_list` method

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -405,7 +405,7 @@ class Resource(object):
         if not getattr(data, 'should_prepare', True):
             prepped_data = data.value
         else:
-            prepped_data = [self.prepare(item) for item in data]
+            prepped_data = self.prepare_list(data)
 
         final_data = self.wrap_list_response(prepped_data)
         return self.serializer.serialize(final_data)
@@ -431,6 +431,20 @@ class Resource(object):
             prepped_data = self.prepare(data)
 
         return self.serializer.serialize(prepped_data)
+
+    def prepare_list(self, data):
+        """
+        Given a collection of data (``objects`` or ``dicts``), this will
+        potentially go through & reshape the output with the ``self.prepare``
+        method.
+
+        :param data: A collection to prepare for serialization
+        :type data: list or iterable
+
+        :returns: A potentially reshaped collection
+        :rtype: list
+        """
+        return [self.prepare(item) for item in data]
 
     def prepare(self, data):
         """


### PR DESCRIPTION
Moved the list preparation out of the `Resource.serialize_list` method, and into `Resource.prepare_list`, which allows for customised list preparation options.

This is useful is if you're using `marshmallow`, where simply calling [Schema.load](https://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.load) multiple times will prevent the pre and post processing methods to work properly, see [here](https://marshmallow.readthedocs.io/en/latest/extending.html#passing-many).

If this gets approved, I'll update the docs and test suite