### PR TITLE
Flask - Use `as_list` and `as_detail` in favour of `as_view`

### DIFF
--- a/restless/fl.py
+++ b/restless/fl.py
@@ -13,7 +13,7 @@ class FlaskResource(Resource):
     Flask environment.
     """
     @classmethod
-    def as_list(cls, *init_args, **init_kwargs):
+    def as_view(cls, view_type, *init_args, **init_kwargs):
         # Overridden here, because Flask uses a global ``request`` object
         # rather than passing it to each view.
         def _wrapper(*args, **kwargs):
@@ -21,20 +21,7 @@ class FlaskResource(Resource):
             # instances.
             inst = cls(*init_args, **init_kwargs)
             inst.request = request
-            return inst.handle('list', *args, **kwargs)
-
-        return _wrapper
-
-    @classmethod
-    def as_detail(cls, *init_args, **init_kwargs):
-        # Overridden here, because Flask uses a global ``request`` object
-        # rather than passing it to each view.
-        def _wrapper(*args, **kwargs):
-            # Make a new instance so that no state potentially leaks between
-            # instances.
-            inst = cls(*init_args, **init_kwargs)
-            inst.request = request
-            return inst.handle('detail', *args, **kwargs)
+            return inst.handle(view_type, *args, **kwargs)
 
         return _wrapper
 


### PR DESCRIPTION
`Resource.as_view` was added in 6c3e83cc12e45c8706ca064053e69d5812bb12f6, in 2014, but the `FlaskResource` was not updated to use it.