### PR TITLE
Add possibility to use different preparers for list and detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov
 *.swp
 .idea/
 *.whl
+.python-version

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,10 @@ The test suite uses tox_ for simultaneous support of multiple versions of both
 Python and Django. The current versions of Python supported are:
 
 * CPython 2.7
+<<<<<<< HEAD
+=======
+* CPython 3.4
+>>>>>>> Remove Python 3.3
 * CPython 3.5
 * CPython 3.6
 * CPython 3.7

--- a/README.rst
+++ b/README.rst
@@ -158,10 +158,6 @@ The test suite uses tox_ for simultaneous support of multiple versions of both
 Python and Django. The current versions of Python supported are:
 
 * CPython 2.7
-<<<<<<< HEAD
-=======
-* CPython 3.4
->>>>>>> Remove Python 3.3
 * CPython 3.5
 * CPython 3.6
 * CPython 3.7

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -446,20 +446,6 @@ class Resource(object):
         """
         return self.list_preparer.prepare(data)
 
-    def prepare_detail(self, data):
-        """
-        Given an item (``object`` or ``dict``), this will potentially go through
-        & reshape the output based on ``self.prepare_with`` object.
-        Special method to be used when prepating detail-style endpoints.
-
-        :param data: An item to prepare for serialization
-        :type data: object or dict
-
-        :returns: A potentially reshaped dict
-        :rtype: dict
-        """
-        return self.detail_preparer.prepare(data)
-
     def prepare(self, data):
         """
         Given an item (``object`` or ``dict``), this will potentially go through
@@ -474,8 +460,6 @@ class Resource(object):
 
         if self.endpoint == 'list' and hasattr(self, 'list_preparer'):
             return self.prepare_list(data)
-        elif self.endpoint == 'detail' and hasattr(self, 'detail_preparer'):
-            return self.prepare_detail(data)
         else:
             return self.preparer.prepare(data)
 

--- a/restless/tnd.py
+++ b/restless/tnd.py
@@ -126,7 +126,7 @@ class TornadoResource(Resource):
         return self.request.method
 
     def request_body(self):
-        return self.request.body 
+        return self.request.body
 
     def build_response(self, data, status=OK):
         if status == NO_CONTENT:
@@ -150,9 +150,10 @@ class TornadoResource(Resource):
         the way we handle the return value of view_method.
         """
         method = self.request_method()
+        self.endpoint = endpoint
 
         try:
-            if not method in self.http_methods.get(endpoint, {}):
+            if method not in self.http_methods.get(endpoint, {}):
                 raise MethodNotImplemented(
                     "Unsupported method '{}' for {} endpoint.".format(
                         method,
@@ -175,5 +176,3 @@ class TornadoResource(Resource):
 
         status = self.status_map.get(self.http_methods[endpoint][method], OK)
         raise gen.Return(self.build_response(serialized, status=status))
-
-

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -252,6 +252,50 @@ class ResourceTestCase(unittest.TestCase):
             'title': 'Cosmos'
         })
 
+    def test_prepare_detail(self):
+        data = {
+            'title': 'Cosmos',
+            'author': 'Carl Sagan',
+            'short_desc': 'A journey through the stars by an emminent astrophysist.',
+            'pub_date': '1980',
+            'index': '7',
+        }
+        self.res.handle('detail')
+
+        self.res.detail_preparer = FieldsPreparer(fields={
+            'title': 'title',
+            'author': 'author',
+            'synopsis': 'short_desc',
+            'date_published': 'pub_date',
+        })
+        self.assertEqual(self.res.prepare(data), {
+            'author': 'Carl Sagan',
+            'synopsis': 'A journey through the stars by an emminent astrophysist.',
+            'title': 'Cosmos',
+            'date_published': '1980',
+        })
+
+    def test_prepare_list(self):
+        data = {
+            'title': 'Cosmos',
+            'author': 'Carl Sagan',
+            'short_desc': 'A journey through the stars by an emminent astrophysist.',
+            'pub_date': '1980',
+            'index': '7',
+        }
+        self.res.handle('list')
+
+        self.res.list_preparer = FieldsPreparer(fields={
+            'title': 'title',
+            'author': 'author',
+            'index': 'index',
+        })
+        self.assertEqual(self.res.prepare(data), {
+            'title': 'Cosmos',
+            'author': 'Carl Sagan',
+            'index': '7',
+        })
+
     def test_wrap_list_response(self):
         data = ['one', 'three', 'two']
         self.assertEqual(self.res.wrap_list_response(data), {

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -252,29 +252,6 @@ class ResourceTestCase(unittest.TestCase):
             'title': 'Cosmos'
         })
 
-    def test_prepare_detail(self):
-        data = {
-            'title': 'Cosmos',
-            'author': 'Carl Sagan',
-            'short_desc': 'A journey through the stars by an emminent astrophysist.',
-            'pub_date': '1980',
-            'index': '7',
-        }
-        self.res.handle('detail')
-
-        self.res.detail_preparer = FieldsPreparer(fields={
-            'title': 'title',
-            'author': 'author',
-            'synopsis': 'short_desc',
-            'date_published': 'pub_date',
-        })
-        self.assertEqual(self.res.prepare(data), {
-            'author': 'Carl Sagan',
-            'synopsis': 'A journey through the stars by an emminent astrophysist.',
-            'title': 'Cosmos',
-            'date_published': '1980',
-        })
-
     def test_prepare_list(self):
         data = {
             'title': 'Cosmos',
@@ -283,6 +260,7 @@ class ResourceTestCase(unittest.TestCase):
             'pub_date': '1980',
             'index': '7',
         }
+
         self.res.handle('list')
 
         self.res.list_preparer = FieldsPreparer(fields={


### PR DESCRIPTION
This PR proposes to add the possibility to use different a preparer for list and detail endpoints only by adding the `list_preparer` or `detail_preparer` as attributes of your resource, in addition to the `preparer` attribute.
We could also give even more flexibility for the user. Maybe some easy way for the user to create its own rules. Just wanted to know what you guys think about it. 