### PR TITLE
response status override using self.status

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -79,7 +79,7 @@ class Resource(object):
         self.request = None
         self.data = None
         self.endpoint = None
-        self.status = 200
+        self.status = None
 
     @classmethod
     def as_list(cls, *init_args, **init_kwargs):
@@ -288,7 +288,11 @@ class Resource(object):
         except Exception as err:
             return self.handle_error(err)
 
-        status = self.status_map.get(self.http_methods[endpoint][method], OK)
+        if self.status is not None:
+            status = self.status
+        else:
+            status = self.status_map.get(self.http_methods[endpoint][method], OK)
+
         return self.build_response(serialized, status=status)
 
     def handle_error(self, err):


### PR DESCRIPTION
`Resource.status` is currently being set but not used:
https://github.com/toastdriven/restless/blob/2.1.1/restless/resources.py#L82

An idea is to use it for overriding a successful response status, no matter the endpoint/method.
Example:
```
def update(self, pk):
    try:
        Post = Post.objects.get(id=pk)
        self.status = 200
    except Post.DoesNotExist:
        self.status = 201
        post = Post()
    
    post.title = self.data['title']
    post.user = User.objects.get(username=self.data['author'])
    post.content = self.data['body']
    post.save()
    return post
```
Fixes #118 
If this gets accepted, please add it to documentation.