### PR TITLE
Add on_delete keyword argument on Django model class tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -134,7 +134,7 @@ a ``posts`` application, which has a model setup like so...::
 
 
     class Post(models.Model):
-        user = models.ForeignKey(User, related_name='posts')
+        user = models.ForeignKey(User, related_name='posts', on_delete=models.PROTECT)
         title = models.CharField(max_length=128)
         slug = models.SlugField(blank=True)
         content = models.TextField(default='', blank=True)


### PR DESCRIPTION
I followed the [Django tutorial](https://restless.readthedocs.io/en/latest/tutorial.html) and If follow the code *as is*, Django complaints about the missing `on_delete` kwarg argument. [`on_delete`](https://docs.djangoproject.com/en/3.2/ref/models/fields/#foreignkey) is required to ForeignKey attributes so this PR adds this argument on the tutorial.