### PR TITLE
Make url() import compatible with Django 4

### DIFF
--- a/restless/dj.py
+++ b/restless/dj.py
@@ -1,7 +1,12 @@
 import six
 
 from django.conf import settings
-from django.conf.urls import url
+
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.http import HttpResponse, Http404


### PR DESCRIPTION
The following was deprecated in Django-3 and removed in Django-4
```
django.conf.urls
```

The change attempts to import the v3 first and if that fails attempts to import v4 and alias to v3.