### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -18,7 +18,7 @@ do something like::
         def is_authenticated(self):
             return self.request.user.is_authenticated()
 
-If you need a more fine graned authentication you could check your current endpoint and do something like that::
+If you need a more fine grained authentication you could check your current endpoint and do something like that::
 
     class MyResource(DjangoResource):
         def is_authenticated(self):

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -146,7 +146,7 @@ in your browser & get a JSON schema view!
 Customizing Data Output
 =======================
 
-There are four approaches to customizing your data ouput.
+There are four approaches to customizing your data output.
 
 #. The built-in ``Preparer/FieldsPreparer`` (simple)
 #. The included ``SubPreparer/CollectionSubPreparer`` (slightly more complex)

--- a/docs/releasenotes/v2.0.0.rst
+++ b/docs/releasenotes/v2.0.0.rst
@@ -58,7 +58,7 @@ Porting is simply 1.adding an import & 2. changing the assignment.::
 Serialization
 ~~~~~~~~~~~~~
 
-Serialization is even easier. If you performed no overridding, there's nothing
+Serialization is even easier. If you performed no overriding, there's nothing
 to update. You simply get the new ``JSONSerializer`` object automatically.
 
 If you were overriding either ``raw_deserialize`` or ``raw_serialize``, you

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -30,7 +30,7 @@ ORM/data source. If you can import a module to work with the data & can
 represent it as JSON, Restless can work with it.
 
 Restless is small & easy to keep in your head. Common usages involve
-overridding just a few easily remembered method names. Total source code is
+overriding just a few easily remembered method names. Total source code is
 a under a thousand lines of code.
 
 Restless supports Python 3 **first**, but has backward-compatibility to work

--- a/restless/resources.py
+++ b/restless/resources.py
@@ -551,7 +551,7 @@ class Resource(object):
         """
         Updates the entire collection for a PUT on a list-style endpoint.
 
-        Uncommonly implemented due to the complexity & (varying) busines-logic
+        Uncommonly implemented due to the complexity & (varying) business-logic
         involved.
 
         **MUST BE OVERRIDDEN BY THE USER** - By default, this returns


### PR DESCRIPTION
There are small typos in:
- docs/cookbook.rst
- docs/extending.rst
- docs/releasenotes/v2.0.0.rst
- docs/tutorial.rst
- restless/resources.py

Fixes:
- Should read `overriding` rather than `overridding`.
- Should read `output` rather than `ouput`.
- Should read `grained` rather than `graned`.
- Should read `business` rather than `busines`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md