### PR TITLE
Add a GitHub Action to run tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,21 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox:
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.9']  # ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+        dj: ['32']  # , '42', '50']
+        fl: ['20']  # , '30']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py39-dj32-fl20


### PR DESCRIPTION
Test results: https://github.com/cclauss/restless/actions
```
py39-dj32-fl20: commands[0]> pytest --cov=restless
============================= test session starts ==============================
platform linux -- Python 3.9.18, pytest-7.4.4, pluggy-1.3.0
cachedir: .tox/py39-dj32-fl20/.pytest_cache
rootdir: /home/runner/work/restless/restless
plugins: cov-4.1.0
collected 91 items

tests/test_dj.py ...............                                         [ 16%]
tests/test_fl.py .....                                                   [ 21%]
tests/test_preparers.py ................                                 [ 39%]
tests/test_pyr.py .....                                                  [ 45%]
tests/test_resources.py ................................                 [ 80%]
tests/test_serializers.py ...                                            [ 83%]
tests/test_tnd.py ..............                                         [ 98%]
tests/test_utils.py .                                                    [100%]

======================= 91 passed, 11 warnings in 1.08s ========================
.pkg: _exit> python /opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py39-dj32-fl20: OK (15.53=setup[13.66]+cmd[1.87] seconds)
  congratulations :) (15.71 seconds)
