### PR TITLE
Issue 104 resolved 

### DIFF
--- a/restless/resources.py
+++ b/restless/resources.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import sys
-
+import logging
 from .constants import OK, CREATED, ACCEPTED, NO_CONTENT
 from .data import Data
 from .exceptions import MethodNotImplemented, Unauthorized
@@ -286,6 +286,7 @@ class Resource(object):
             data = view_method(*args, **kwargs)
             serialized = self.serialize(method, endpoint, data)
         except Exception as err:
+            logging.error('Exception occurred', exc_info=True)
             return self.handle_error(err)
 
         status = self.status_map.get(self.http_methods[endpoint][method], OK)

--- a/restless/tnd.py
+++ b/restless/tnd.py
@@ -5,6 +5,9 @@ from .exceptions import MethodNotImplemented, Unauthorized
 
 import weakref
 import inspect
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 try:
@@ -171,8 +174,8 @@ class TornadoResource(Resource):
                 data = yield data
             serialized = self.serialize(method, endpoint, data)
         except Exception as err:
+            logger.exception('Unhandled exception occurred: %s', err)
             raise gen.Return(self.handle_error(err))
-
         status = self.status_map.get(self.http_methods[endpoint][method], OK)
         raise gen.Return(self.build_response(serialized, status=status))
 


### PR DESCRIPTION
To solve the problem of logging uncaught exceptions, we need to import the logging library and add a logging statement before returning the error response in the `handle` method of the `Resource` class.
To solve the problem of logging uncaught exceptions, we need to import the logging library, initialize the logger, and add a logging statement inside the except block to log the exception.